### PR TITLE
fix: ajustando bug na tela de caixa

### DIFF
--- a/src/pages/StoreCash/index.tsx
+++ b/src/pages/StoreCash/index.tsx
@@ -150,7 +150,7 @@ const StoreCash: React.FC<IProp> = ({ history }) => {
         id: 1,
         label: "Abertura",
         value: currencyFormater(
-          +_storeCashHistory?.amount_on_open || +storeCash.amount_on_open
+          +_storeCashHistory?.amount_on_open || +storeCash?.amount_on_open
         ),
       },
       {


### PR DESCRIPTION
Na pagina de gerenciamento de caixa, ocorre um erro ao abri-la se caso a propriedade amount_on_open seja nula  da tabela storeCash, isso acaba quebrando a pagina, para corrigir foi adicionado a propriedade opcional storeCash?.amount_on_open.