### PR TITLE
Fix - Ajustando texto em vendas

### DIFF
--- a/src/containers/SalesHistory/index.tsx
+++ b/src/containers/SalesHistory/index.tsx
@@ -78,7 +78,7 @@ const SalesHistory: React.FC<IProps> = ({
                 <Row>
                   <Col sm={24}>
                     Valor:
-                    <span>R$:{sale.total_sold.toFixed(2)}</span>
+                    <span>R$ {sale.total_sold.toFixed(2)}</span>
                   </Col>
                 </Row>
               </CardSale>


### PR DESCRIPTION
Page SalesHistory - QA ID#41: Remoção de " : " do texto de valor.
- Alteração de texto de "Valor: R$:valor" para "Valor: R$ valor"