### PR TITLE
Feature - Adicionando tooltip na coluna NFC-e de vendas

### DIFF
--- a/src/pages/Sale/index.tsx
+++ b/src/pages/Sale/index.tsx
@@ -345,22 +345,28 @@ const Sale: React.FC<IProps> = () => {
       authorized: (
         <>
           <Col sm={8}>
-            <PrinterIcon
-              style={{ width: "30%" }}
-              onClick={() => printDanfe(selectedSale)}
-            />
+            <Tooltip title="Imprimir Danfe" placement="bottom">
+              <PrinterIcon
+                style={{ width: "30%" }}
+                onClick={() => printDanfe(selectedSale)}
+              />
+            </Tooltip>
           </Col>
           <Col sm={8}>
-            <CancelIcon
-              style={{ width: "30%" }}
-              onClick={() => cancelNfce(selectedSale)}
-            />
+            <Tooltip title="Cancelar NFCe" placement="bottom">
+              <CancelIcon
+                style={{ width: "30%" }}
+                onClick={() => cancelNfce(selectedSale)}
+              />
+            </Tooltip>
           </Col>
           <Col sm={8}>
-            <PdfIcon
-              style={{ width: "30%" }}
-              onClick={() => getNfceDanfe(selectedSale)}
-            />
+            <Tooltip title="Baixar PDF" placement="bottom">
+              <PdfIcon
+                style={{ width: "30%" }}
+                onClick={() => getNfceDanfe(selectedSale)}
+              />
+            </Tooltip>
           </Col>
         </>
       ),


### PR DESCRIPTION
Page Sales - QA ID#48: Botões da coluna NFC-e não tem tooltip.
- Adição de tooltip nos icones da coluna de NFC-e.