### PR TITLE
Fix - Ajustando tamanho de texto do botão e obs de cupom

### DIFF
--- a/src/containers/CupomModal/index.tsx
+++ b/src/containers/CupomModal/index.tsx
@@ -227,7 +227,7 @@ const CupomModal: React.FC = () => {
           loading={loading}
           onClick={onCancel}
         >
-          Cancelar
+          <span className="buttonSpan">Cancelar</span>
         </Button>
       ) : (
         <Button
@@ -237,7 +237,7 @@ const CupomModal: React.FC = () => {
           onClick={onFinish}
           disabled={!!sale.payments.length}
         >
-          Resgatar
+          <span className="buttonSpan">Resgatar</span>
         </Button>
       )}
     </Container>

--- a/src/containers/CupomModal/styles.ts
+++ b/src/containers/CupomModal/styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 import {
   Input as InputAnt,
@@ -10,7 +10,11 @@ import {
 
 export const Container = styled(ModalAnt)`
   span {
-    font-size: 10px;
+    font-size: 0.8rem;
+  }
+  .buttonSpan {
+    font-size: 1.4rem;
+    font-weight: 500;
   }
 `;
 
@@ -24,13 +28,15 @@ export const Row = styled(RowAnt)`
 export const Col = styled(ColAnt)``;
 
 export const Button = styled(ButtonAnt)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   height: 3.7rem;
   width: 100%;
   border-radius: 0.7rem;
   background: var(--orange-250);
   border: none;
-  font-size: 1.4rem;
-  font-weight: 500;
+
   box-shadow: rgba(0, 0, 0, 0.15) 1.95px 1.95px 2.6px;
   margin-top: 10px;
   :active,


### PR DESCRIPTION
Modal cupom. QA ID#80: Os textos abaixo do campo de texto estão muito pequenos, principalmente do botão de Resgatar e Cancelar.
- Alteração na className do texto do botão "Registrar"/"Cancelar".
- Alteração no font-size dos spans.