### PR TITLE
Feature - Trocando tab inicialmente aberta em balanço

### DIFF
--- a/src/pages/Balance/index.tsx
+++ b/src/pages/Balance/index.tsx
@@ -397,7 +397,7 @@ const Balance: React.FC = () => {
 
               <TabContainer>
                 <Tabs
-                  defaultActiveKey="1"
+                  defaultActiveKey="billing"
                   onChange={(id_tab) => setCurrentTab(id_tab)}
                 >
                   {createTabPanes(balance).map((_tab) => (


### PR DESCRIPTION
Page Balance. QA ID#45: Deixar Estatísticas do "Faturamento Total" como padrão, ao clicar em Balanço aparece apenas do Delivery inicialmente.
- Modificação em defaultActiveKey para mostrar "Faturamento Total" inicialmente ao abrir a page "Balanço".