### PR TITLE
refact: alterando comparação de category.name

### DIFF
--- a/src/containers/InOutForm/index.tsx
+++ b/src/containers/InOutForm/index.tsx
@@ -105,7 +105,7 @@ const InOutForm: React.FC<IProps> = ({ modalState, setModalState, type }) => {
       }
       if (reasontype === "Pagamento freelance") {
         const category = productsCategory.find(
-          (category) => category.name === "Salarios/Comissões"
+          (category) => category.id === 12
         );
         const product = category.products.find(
           (product) =>


### PR DESCRIPTION
Alterando comparação de category.name por category.id, pois se caso alguém mude o nome da categoria "Salarios/Comissoes" no banco  de dados irá ocorrer um erro na hora de fazer um post de cashHandler.

Seria interessante tirar o nome estatico: Salarios/Comissões ? Na hora de enviar o post para api mercury no gestor. Ou deixa estático ou acrescenta o nome que vem do get de products_category/purchase.
![image](https://user-images.githubusercontent.com/58057135/233452636-05be04c6-23b3-4028-94a1-cd6402498522.png)
