### PR TITLE
Refact input forma de pagamento nfce

### DIFF
--- a/src/pages/Nfce/index.tsx
+++ b/src/pages/Nfce/index.tsx
@@ -187,7 +187,13 @@ const Nfce: React.FC = () => {
   };
 
   const handleEmit = async () => {
-    let payload = form.getFieldsValue();
+    let payload = await form.getFieldsValue();
+    if (!payload.formaPagamento) {
+      return notification.warning({
+        message: "Selecione a forma de pagamento",
+        duration: 5,
+      });
+    }
     if (!productsNfe.length) {
       return notification.warning({
         message: "Oops! O carrinho está vazio.",


### PR DESCRIPTION
Foi adicionado um warning no input de forma de pagamento na tela de NFC-e.
![Untitled](https://github.com/Amadelli-TheBestAcai/thebestacai-gestor-de-vendas/assets/58057135/69bcdf4f-3fc1-43c2-8974-eec22850418f)
