### PR TITLE
refact: alterando calculo do valor do item do carrinho

### DIFF
--- a/electron/src/usecases/sale/addItem.ts
+++ b/electron/src/usecases/sale/addItem.ts
@@ -48,13 +48,13 @@ class AddItem implements IUseCaseFactory {
         update_stock: product?.category.id !== 1 ? true : false,
         product,
         storeProduct,
-        total: +(productToAdd.price_unit || 0) * quantity,
+        total: price ? price : + (productToAdd.price_unit || 0) * quantity,
         created_at: moment(new Date()).format("DD/MM/YYYY HH:mm:ss"),
       });
     }
 
     sale.total_sold = +sale.items
-      .reduce((total, item) => Math.round(item.total) + total, 0)
+      .reduce((total, item) => item.total + total, 0)
       .toFixed(2);
 
     sale.quantity = sale.items.reduce(

--- a/electron/src/usecases/sale/addItem.ts
+++ b/electron/src/usecases/sale/addItem.ts
@@ -54,7 +54,7 @@ class AddItem implements IUseCaseFactory {
     }
 
     sale.total_sold = +sale.items
-      .reduce((total, item) => item.total + total, 0)
+      .reduce((total, item) => Math.round(item.total) + total, 0)
       .toFixed(2);
 
     sale.quantity = sale.items.reduce(

--- a/electron/src/usecases/sale/decressItem.ts
+++ b/electron/src/usecases/sale/decressItem.ts
@@ -39,7 +39,7 @@ class DecressItem implements IUseCaseFactory {
     }
     sale.total_sold = sale.items.reduce(
       (total, item) =>
-        +(item.storeProduct?.price_unit || 0) * item?.quantity + total,
+        Math.round(+(item.storeProduct?.price_unit || 0) * (item?.quantity || 0)) + total,
       0
     );
 

--- a/electron/src/usecases/sale/decressItem.ts
+++ b/electron/src/usecases/sale/decressItem.ts
@@ -37,14 +37,14 @@ class DecressItem implements IUseCaseFactory {
       sale.items[itemIndex].total =
         newQuantity * +(sale.items[itemIndex].storeProduct.price_unit || 0);
     }
-    sale.total_sold = sale.items.reduce(
-      (total, item) =>
-        Math.round(+(item.storeProduct?.price_unit || 0) * (item?.quantity || 0)) + total,
-      0
-    );
+
+    sale.total_sold = +sale.items
+      .reduce((total, item) => item.total + total, 0)
+      .toFixed(2);
 
     sale.quantity = sale.items.reduce(
-      (total, item) => item?.quantity + total,
+      (total, item) =>
+        +item.product?.category.id === 1 ? 1 + total : item.quantity + total,
       0
     );
 


### PR DESCRIPTION
Foi ajustado o valor total do item ao ser adicionado ao carrinho, antes se você adicionasse muitos itens de self-service, o valor total da venda vinha quebrado, e não batia com o somatório do carrinho. Tinha uma diferença de centavos se comparasse o valor total da venda com o valor total do carrinho.

![image](https://github.com/Amadelli-TheBestAcai/thebestacai-gestor-de-vendas/assets/58057135/6b32dc9e-0335-4446-930e-464c61fd0e46)
