### PR TITLE
feat: add mensagem de erro de nfce

### DIFF
--- a/src/pages/Nfce/index.tsx
+++ b/src/pages/Nfce/index.tsx
@@ -230,6 +230,14 @@ const Nfce: React.FC = () => {
       } = await window.Main.sale.emitNfce(nfcePayload);
 
       if (errorOnEmitNfce) {
+        if (error_message === "Store token not found.") {
+          notification.error({
+            message: "O token da nota fiscal não está cadastrado na loja.",
+            duration: 5,
+          });
+          return;
+        }
+
         notification.error({
           message: error_message || "Erro ao emitir NFCe",
           duration: 5,


### PR DESCRIPTION
Foi adicionado uma mensagem mais intuitiva para o usuário, quando não estiver cadastrado o token da nota fiscal.

![image](https://github.com/Amadelli-TheBestAcai/thebestacai-gestor-de-vendas/assets/58057135/35c2c984-b779-476f-b247-f4678dc488bf)


