### PR TITLE
refact: alterando decodificação da nfce

### DIFF
--- a/src/pages/Sale/index.tsx
+++ b/src/pages/Sale/index.tsx
@@ -258,11 +258,7 @@ const Sale: React.FC<IProps> = () => {
       },
     });
 
-    const { data: html } = await axios({
-      method: "GET",
-      responseType: "text",
-      url: `data:pdf;base64,${data.content}`,
-    });
+    const html = Buffer.from(data.content, 'base64').toString('utf-8');
 
     const reaplaceQrcode = async (_html) => {
       const [beforeQrcodeDiv, afterQrcodeDiv] = _html.split(


### PR DESCRIPTION
Alterei um trecho do código para ser utilizado a classe Buffer nativa do node para decodificar a nfce que vem como base64, pois antes como era decodificado não reconhecia os caracteres especiais e acentos como texto. Com essa alteração palavras com acentos são reconhecidas.

![image](https://github.com/Amadelli-TheBestAcai/thebestacai-gestor-de-vendas/assets/58057135/921b933e-cf10-46fa-a2bc-d13a0672879d)
