### PR TITLE
style: add cor black opaco ao botao

### DIFF
--- a/src/pages/Delivery/styles.ts
+++ b/src/pages/Delivery/styles.ts
@@ -386,7 +386,7 @@ export const ButtonCancel = styled.button`
 export const ButtonConfirm = styled.button`
   ${ButtonCSS}
   background: var(--orange-450);
-  color: var(--brown-500);
+  color: var(--black-opaco);
   margin-left: 1rem;
 `;
 


### PR DESCRIPTION
Padronizando a cor dos botões da tela Home e Delivery para black opaco.