### PR TITLE
refact: add warning de habilitar impressao

### DIFF
--- a/src/pages/Sale/index.tsx
+++ b/src/pages/Sale/index.tsx
@@ -340,6 +340,25 @@ const Sale: React.FC<IProps> = () => {
     document.body.removeChild(link);
   };
 
+  const printReceipt = async (sale: SaleFromApi) => {
+    const { response: _settings, has_internal_error: errorOnSettings } =
+      await window.Main.settings.getSettings();
+    if (errorOnSettings) {
+      notification.error({
+        message: "Erro ao encontrar configurações",
+        duration: 5,
+      });
+    }
+
+    if (_settings.should_use_printer === false) {
+      return notification.warning({
+        message: "Habilite a impressora na tela de configurações",
+        duration: 5,
+      });
+    }
+    window.Main.common.printSale(sale);
+  };
+
   const nfceInfo = (selectedSale: SaleFromApi) => {
     return {
       authorized: (
@@ -465,10 +484,9 @@ const Sale: React.FC<IProps> = () => {
                                     />
                                   </Tooltip>
                                 )}
-                              <Tooltip title="Imprimir" placement="bottom">
+                              <Tooltip title="Imprimir Cupom fiscal" placement="bottom">
                                 <PrinterIcon
-                                  onClick={() =>
-                                    window.Main.common.printSale(selectedSale)
+                                  onClick={() => printReceipt(selectedSale)
                                   }
                                 />
                               </Tooltip>


### PR DESCRIPTION
Foi adicionado um warning na tela de vendas, que indica ao usuário para habilitar a impressora na tela de configurações caso a mesma esteja desabilitada. .

![image](https://github.com/Amadelli-TheBestAcai/thebestacai-gestor-de-vendas/assets/58057135/92c378f6-0497-426c-a8bd-4e28304ae3c7)

Também acrescentei uma mensagem mais intuitiva no tooltip de cupom fiscal
![image](https://github.com/Amadelli-TheBestAcai/thebestacai-gestor-de-vendas/assets/58057135/4f8b074d-a78d-4371-b241-352fc18b44b9)
