### PR TITLE
feat: criação de mensagem de aviso para sangria

### DIFF
--- a/src/context/globalContext.tsx
+++ b/src/context/globalContext.tsx
@@ -209,9 +209,9 @@ export function GlobalProvider({ children }) {
     if (
       +(currentSale.total_sold.toFixed(2) || 0) >
       currentSale.total_paid +
-        ((currentSale.discount || 0) +
-          (currentSale.customer_nps_reward_discount || 0)) +
-        0.5
+      ((currentSale.discount || 0) +
+        (currentSale.customer_nps_reward_discount || 0)) +
+      0.5
     ) {
       return notification.warning({
         message: "Pagamento inválido!",
@@ -310,7 +310,7 @@ export function GlobalProvider({ children }) {
       if (
         settings.should_open_casher === true &&
         error_message ===
-          "Nenhum caixa está disponível para abertura, entre em contato com o suporte"
+        "Nenhum caixa está disponível para abertura, entre em contato com o suporte"
       ) {
         const { response: _newSettings, has_internal_error: errorOnSettings } =
           await window.Main.settings.update(settings.id, {
@@ -331,13 +331,26 @@ export function GlobalProvider({ children }) {
 
       error_message
         ? notification.warning({
-            message: error_message,
-            duration: 5,
-          })
+          message: error_message,
+          duration: 5,
+        })
         : notification.error({
-            message: "Erro ao finalizar venda",
-            duration: 5,
-          });
+          message: "Erro ao finalizar venda",
+          duration: 5,
+        });
+    }
+
+    const { response: _balance } =
+      await window.Main.storeCash.getStoreCashBalance();
+
+    const paymentMoneyType = sale?.payments?.map((payment) => payment).find((moneyItem) => moneyItem.type === 0)
+
+    if (paymentMoneyType && _balance?.store?.money > 500) {
+      notification.warning({
+        message:
+          "ATENÇÃO: O saldo em dinheiro no caixa está elevado. Considere fazer uma sangria",
+        duration: 5,
+      });
     }
 
     const { response: _newSale, has_internal_error: errorOnBuildNewSale } =

--- a/src/pages/Sale/index.tsx
+++ b/src/pages/Sale/index.tsx
@@ -130,8 +130,6 @@ const Sale: React.FC<IProps> = () => {
     const currentTime = moment();
     const timeDifference = currentTime.diff(creationTime, 'minutes');
 
-    console.log(hasNfce)
-
     Modal.confirm({
       title: hasNfce ?
         (hasNfce.status_sefaz !== '100') ? 'Ocorreu um erro ao tentar emitir a nota fiscal. Deletar a venda mesmo assim?' :
@@ -145,7 +143,6 @@ const Sale: React.FC<IProps> = () => {
           Deseja prosseguir com esta ação?`
         :
         'Não foi emitida a nota fiscal da venda. Gostaria de removê-la mesmo assim?',
-
       content: renderTextArea,
       okText: "Sim",
       okType: "default",


### PR DESCRIPTION
# Aviso de sangria

## Descrição
Criação de mensagem de aviso caso as vendas em dinheiro ultrapassem os 500 reais, sugerindo fazer uma sangria.

## Alterações Realizadas
- Alteração no fluxo de vendas para exibir a mensagem

## Testes Realizados
- Testes locais

## Screenshots
![image](https://github.com/Amadelli-TheBestAcai/thebestacai-gestor-de-vendas/assets/86072289/46ea8cfa-6524-404f-b1c1-287a4e22921b)

## Checklist
- [x] As alterações foram testadas localmente e estão funcionando corretamente

## Observações Adicionais
- A mensagem será exibida SOMENTE ao ultrapassar o valor e realizar vendas em DINHEIRO
