### PR TITLE
feature: adicionando msg de caixa offline em vendas e movimentações

### DIFF
--- a/src/containers/SideBar/index.tsx
+++ b/src/containers/SideBar/index.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from "react";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 
+import { useUser } from "../../hooks/useUser";
+import { useSale } from "../../hooks/useSale";
+
 import LogoImg from "../../assets/img/logo-login.png";
 
-import { Modal, Tooltip } from "antd";
+import { Modal, Tooltip, notification } from "antd";
 
 import {
   Container,
@@ -23,16 +26,26 @@ import {
   LogOutIcon,
   TrashIcon,
 } from "./styles";
-import { useUser } from "../../hooks/useUser";
 
 type IProps = RouteComponentProps;
 
 const SideBar: React.FC<IProps> = ({ history }) => {
   const [visible, setVisible] = useState(false);
+  const { storeCash } = useSale();
   const { hasPermission } = useUser();
 
   const handleClick = (id: number, route: string): void => {
-    history.push(route);
+    if (!storeCash.is_online && (route === "/handler" || route === "/sale")) {
+      notification.info({
+        message: "Caixa offline",
+        description: `O caixa deve estar online para acessar a tela de ${
+          route === "/handler" ? "Movimentações" : "Vendas"
+        }`,
+        duration: 3,
+      });
+    } else {
+      history.push(route);
+    }
 
     if (id === 10) {
       Modal.confirm({

--- a/src/pages/Delivery/index.tsx
+++ b/src/pages/Delivery/index.tsx
@@ -522,7 +522,6 @@ const Delivery: React.FC<ComponentProps> = () => {
                       <h2>Delivery</h2>
                     </Header>
                     <Tabs
-                      defaultActiveKey="1"
                       centered
                       onChange={(type) => setDeliveryType(+type)}
                     >


### PR DESCRIPTION
# Melhoria gestor de venda - Vendas e Movimentações

## Descrição

Quando o usuário abre um caixa no Gestor de vendas e logo em seguida clica na tela de vendas, retorna um erro 500, pois no corpo da requisição é enviado /OFFLINE-(Numero do caixa). Ocorre o problema pq ainda não deu tempo do caixa ficar Online. Uma possível solução seria adicionar uma verificação onde caso o storeCash ainda esteja offline retornar um SVG escrito: Seu caixa precisa estar online para abrir a tela de vendas.

## Alterações Realizadas

- Adicionada mensagem que indica que o caixa deve estar online para acessar as telas de movimentações e de vendas;

## Testes Realizados

- Com o caixa offline, clicar nos icones de vendas e movimentações no menu.

## Screenshots

![image](https://github.com/Amadelli-TheBestAcai/thebestacai-gestor-de-vendas/assets/108304028/08e0ec71-00b0-4b23-a31c-1f5ab0a2c7b1)


## Checklist

- [x] As alterações foram testadas localmente e estão funcionando corretamente
- [x] O código está de acordo com as diretrizes de estilo do projeto
- [x] Todos os testes foram executados com sucesso