### PR TITLE
Fix/luis bug reward

### DIFF
--- a/src/containers/Actions/index.tsx
+++ b/src/containers/Actions/index.tsx
@@ -106,7 +106,7 @@ const Actions: React.FC<ComponentProps> = ({ history }) => {
     if (storeCash && !storeCash?.is_online) {
       const { response: _storeCash } = await window.Main.storeCash.getCurrent();
 
-      if (_storeCash && _storeCash.is_online) {
+      if (_storeCash && _storeCash?.is_online) {
         setStoreCash(_storeCash);
       }
     }

--- a/src/containers/Actions/index.tsx
+++ b/src/containers/Actions/index.tsx
@@ -46,6 +46,8 @@ const Actions: React.FC<ComponentProps> = ({ history }) => {
     campaign,
     setCampaign,
     setShouldOpenClientInfo,
+    storeCash,
+    setStoreCash,
   } = useSale();
   const [cupomModalState, setCupomModalState] = useState(false);
   const { store } = useStore();
@@ -100,6 +102,18 @@ const Actions: React.FC<ComponentProps> = ({ history }) => {
     }
   }, [sale.client_cpf]);
 
+  const modalReward = async () => {
+    if (!storeCash.is_online) {
+      const { response: _storeCash } = await window.Main.storeCash.getCurrent();
+
+      if (_storeCash && _storeCash.is_online) {
+        setStoreCash(_storeCash);
+      }
+    }
+
+    setRewardModal(true);
+  };
+
   return (
     <Container>
       <ContentGeneral>
@@ -143,7 +157,7 @@ const Actions: React.FC<ComponentProps> = ({ history }) => {
               )}
             </ButtonCommands>
 
-            <Button onClick={() => setRewardModal(true)}>
+            <Button onClick={() => modalReward()}>
               <TrophyIcon />
               Recompensas
             </Button>

--- a/src/containers/Actions/index.tsx
+++ b/src/containers/Actions/index.tsx
@@ -103,7 +103,7 @@ const Actions: React.FC<ComponentProps> = ({ history }) => {
   }, [sale.client_cpf]);
 
   const modalReward = async () => {
-    if (!storeCash.is_online) {
+    if (storeCash && !storeCash?.is_online) {
       const { response: _storeCash } = await window.Main.storeCash.getCurrent();
 
       if (_storeCash && _storeCash.is_online) {

--- a/src/containers/SideBar/index.tsx
+++ b/src/containers/SideBar/index.tsx
@@ -35,7 +35,11 @@ const SideBar: React.FC<IProps> = ({ history }) => {
   const { hasPermission } = useUser();
 
   const handleClick = (id: number, route: string): void => {
-    if (!storeCash.is_online && (route === "/handler" || route === "/sale")) {
+    if (
+      storeCash &&
+      !storeCash?.is_online &&
+      (route === "/handler" || route === "/sale")
+    ) {
       notification.info({
         message: "Caixa offline",
         description: `O caixa deve estar online para acessar a tela de ${

--- a/src/context/globalContext.tsx
+++ b/src/context/globalContext.tsx
@@ -393,7 +393,7 @@ export function GlobalProvider({ children }) {
 
     const { response: _storeCash } = await window.Main.storeCash.getCurrent();
 
-    if (_storeCash && _storeCash.is_online) {
+    if (_storeCash && _storeCash?.is_online) {
       setStoreCash(_storeCash);
     }
 

--- a/src/context/globalContext.tsx
+++ b/src/context/globalContext.tsx
@@ -391,6 +391,12 @@ export function GlobalProvider({ children }) {
       window.Main.common.printSale(currentSale);
     }
 
+    const { response: _storeCash } = await window.Main.storeCash.getCurrent();
+
+    if (_storeCash && _storeCash.is_online) {
+      setStoreCash(_storeCash);
+    }
+
     document.getElementById("balanceInput")?.focus();
   };
 


### PR DESCRIPTION
# Ajuste modal reward caixa offline

## Descrição

A mensagem de erro dizendo que o caixa precisa estar online para resgatar uma recompensa está aparecendo mesmo com o caixa online. O usuário precisa mudar para a tela de “Gerenciamento de Caixa” depois voltar para a home para então o erro não aparecer novamente.

## Alterações Realizadas

- 

## Testes Realizados

- Adicionada requisição para verificar se o caixa está online caso o usuário pressione o modal de recompensas;
- Adicionada atualização do caixa após uma venda.

## Checklist

- [x] As alterações foram testadas localmente e estão funcionando corretamente
- [x] O código está de acordo com as diretrizes de estilo do projeto
- [ ] Novas dependências foram devidamente documentadas, se aplicável
- [ ] A documentação foi atualizada, se necessário
- [x] Todos os testes foram executados com sucesso
- [ ] A compatibilidade com diferentes navegadores foi verificada, se aplicável