### PR TITLE
fix: ajuste no envio de observação

### DIFF
--- a/src/containers/InOutForm/index.tsx
+++ b/src/containers/InOutForm/index.tsx
@@ -38,6 +38,7 @@ type ShopInfo = {
   discount_value?: number;
   quantity?: number;
   observation?: string;
+  observationFreeLancer?: string;
   name?: string;
 };
 
@@ -136,7 +137,7 @@ const InOutForm: React.FC<IProps> = ({ modalState, setModalState, type }) => {
               quantity: +shopInfo.quantity,
               unitary_value: +shopInfo.unitary_value,
               category_id: +category.id,
-              observation: `Nome: ${shopInfo.observation}`,
+              observation: `${reasontype}: ${shopInfo?.observationFreeLancer}`,
             },
           ],
           purchase_date: new Date(),
@@ -172,7 +173,7 @@ const InOutForm: React.FC<IProps> = ({ modalState, setModalState, type }) => {
           reasontype === "Outros"
             ? reasson
             : reasontype === "Pagamento freelance"
-            ? reasontype + `: ${shopInfo.observation}`
+            ? reasontype + `: ${shopInfo?.observationFreeLancer}`
             : reasontype,
         amount: +shopOrder?.total || value,
       },
@@ -450,7 +451,7 @@ const InOutForm: React.FC<IProps> = ({ modalState, setModalState, type }) => {
                   <Col sm={24}>
                     <Form.Item
                       label="Nome Freelancer"
-                      name="observation"
+                      name="observationFreeLancer"
                       rules={[
                         {
                           required: true,
@@ -461,7 +462,7 @@ const InOutForm: React.FC<IProps> = ({ modalState, setModalState, type }) => {
                       <Input
                         placeholder="Nome Freelancer"
                         onChange={({ target: { value } }) =>
-                          handleShopInfo("observation", value)
+                          handleShopInfo("observationFreeLancer", value)
                         }
                       />
                     </Form.Item>

--- a/src/containers/InOutForm/index.tsx
+++ b/src/containers/InOutForm/index.tsx
@@ -143,6 +143,22 @@ const InOutForm: React.FC<IProps> = ({ modalState, setModalState, type }) => {
           purchase_date: new Date(),
           auto_generated: true,
         };
+
+        if (+shopOrder?.total >= 1000 && +shopOrder?.total <= 9999) {
+          notification.warning({
+            message: "Valor total elevado",
+            description:
+              "Por favor verifique se os valores foram inseridos corretamente através da tela de movimentações.",
+            duration: 10,
+          });
+        } else if (+shopOrder?.total > 9999) {
+          return notification.warning({
+            message: "Valor total muito elevado para pagamento de FreeLancer.",
+            description:
+              "Por favor verifique se os valores foram inseridos corretamente.",
+            duration: 10,
+          });
+        }
       }
       if (!shopIsValid(shopOrder)) {
         return notification.warning({


### PR DESCRIPTION
# ✨ Movimentação Observação

## 📝 Ajuste no payload de movimentação para FreeLance

### 💡 O que esta PR faz?
Ajusta os campos Nome do FreeLancer e Observação para enviar os dados preenchidos separadamente.

### ❓ Por que essas mudanças são necessárias?
Os campos "Nome de FreeLancer" e "Observação" eram ligados entre si, qualquer string digitada em um desses campos refletia automaticamente para o outro.
Isso impedia a entrada das demais informações que deveriam ser colocadas no campo de observação sem alterar o nome do FreeLancer.

### 🔧 Como essas mudanças foram implementadas?
O form "observation" era utilizado para ambos os campos então foi criado um "observationFreeLancer" em "shopInfo" para guardar o valor digitado no campo "Nome do FreeLancer".
Além disso o payload foi alterado para enviar observationFreeLancer como uma observação no item da compra, enquanto o "observation" fica responsável pela compra no geral.

## 🔗 Issue Relacionada
<!-- Se esta PR está relacionada a uma issue, linke-a aqui -->

## ✅ Checklist
- [ ] 🧹 O código está limpo e segue o estilo do projeto
- [ ] 📚 A documentação foi atualizada (se aplicável)
- [ ] 🧪 Testes foram adicionados/atualizados (se aplicável)
- [ ] ✅ Todos os testes estão passando

## 📷 Capturas de Tela (se aplicável)
<!-- Adicione capturas de tela para ilustrar as mudanças, se aplicável -->

## 🛠️ Notas Adicionais
<!-- Adicione qualquer informação adicional que os revisores devem saber -->

## 👥 Revisores
<!-- @mencione os revisores que você gostaria que analisassem esta PR -->
