### PR TITLE
fix: store id alterado para store.company.id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestor-de-vendas",
-  "version": "14.4.4",
+  "version": "14.4.5",
   "author": "Amabest",
   "homepage": "./",
   "description": "Gestor de Vendas",

--- a/src/context/globalContext.tsx
+++ b/src/context/globalContext.tsx
@@ -301,8 +301,8 @@ export function GlobalProvider({ children }) {
     if (
       +(currentSale.total_sold.toFixed(2) || 0) >
       currentSale.total_paid +
-        (combinedDiscount + (currentSale.customer_nps_reward_discount || 0)) +
-        0.5
+      (combinedDiscount + (currentSale.customer_nps_reward_discount || 0)) +
+      0.5
     ) {
       setSavingSale(false);
       return notification.warning({
@@ -348,7 +348,7 @@ export function GlobalProvider({ children }) {
         }
       }
 
-    
+
     }
 
     const voucherDiscount =
@@ -376,7 +376,7 @@ export function GlobalProvider({ children }) {
 
     if (currentSale.customer_reward_id) {
       const payload = {
-        store_id: store.id,
+        store_id: store.company.id,
         user_name: user.name,
         user_id: user.id,
         company_name: store.company.company_name,
@@ -492,7 +492,7 @@ export function GlobalProvider({ children }) {
       if (
         settings.should_open_casher === true &&
         error_message ===
-          "Nenhum caixa está disponível para abertura, entre em contato com o suporte"
+        "Nenhum caixa está disponível para abertura, entre em contato com o suporte"
       ) {
         const { response: _newSettings, has_internal_error: errorOnSettings } =
           await window.Main.settings.update(settings.id, {
@@ -513,13 +513,13 @@ export function GlobalProvider({ children }) {
 
       error_message
         ? notification.warning({
-            message: error_message,
-            duration: 5,
-          })
+          message: error_message,
+          duration: 5,
+        })
         : notification.error({
-            message: "Erro ao finalizar venda",
-            duration: 5,
-          });
+          message: "Erro ao finalizar venda",
+          duration: 5,
+        });
     }
 
     const { response: cashHandlers } =


### PR DESCRIPTION
## Auditoria de resgate de recompensa pegando store_id errado
No resgate da recompensa, estava sendo enviado o valor store.id. Contudo, o objeto store representa o company_user, e não a loja. O objeto da loja se encontra em store.company
Exemplo do payload enviado ao finalizar uma venda com recompensa:
store: {
   "id":218107,
   "user_id":6407,
   "company_id":46,
   "created_at":"2025-09-11T11:09:34.375Z",
   "updated_at":"2025-09-11T11:09:34.375Z",
   "deleted_at":null,
   "company":{
      "id":46,
      "cnpj":"39277142000136",
      "sales_force_id":null,
      "emitente_uf":"MS",
      "emitente_incentivo_fiscal":false,
      "token_nfce_production_id":"000002",
      "state_registration":"MS",
...

### Link da US
https://ogrupothebest.atlassian.net/jira/software/c/projects/AG/boards/204?assignee=712020%3A3e744047-d4bb-4fe6-bedb-707ade07909d&selectedIssue=AG-1604