### PR TITLE
Feat/implmentando novo fluxo cupom

### DIFF
--- a/electron/src/models/dtos/voucher.ts
+++ b/electron/src/models/dtos/voucher.ts
@@ -17,6 +17,19 @@ export type VoucherDTO = {
   points_multiplier: number;
   companies: Company[];
   products: Product[];
+  voucher_type?: string | null;
+  voucher_config?: DiscountByQuantityConfigDTO | null;
+};
+
+export type DiscountByQuantityConfigDTO = {
+  trigger_mode: "product" | "category";
+  trigger_ids: number[];
+  min_combined_quantity: number;
+  quantity_with_discount: number;
+  apply_discount_on: "cheapest" | "most_expensive";
+  discount_value: number;
+  discount_mode: "percent" | "fixed";
+  min_item_grammage: number | null;
 };
 
 type Company = {

--- a/electron/src/usecases/sale/addItem.ts
+++ b/electron/src/usecases/sale/addItem.ts
@@ -62,8 +62,7 @@ class AddItem implements IUseCaseFactory {
       .toFixed(2);
 
     if (sale.customerVoucher?.voucher) {
-      sale.total_sold -= getCustomerVoucherDiscountBrl(sale);
-      sale.total_sold = +sale.total_sold.toFixed(2);
+      sale.discount = +getCustomerVoucherDiscountBrl(sale).toFixed(2);
     }
 
     sale.quantity = sale.items.reduce(

--- a/electron/src/usecases/sale/decressItem.ts
+++ b/electron/src/usecases/sale/decressItem.ts
@@ -44,8 +44,7 @@ class DecressItem implements IUseCaseFactory {
       .toFixed(2);
 
     if (sale.customerVoucher?.voucher) {
-      sale.total_sold -= getCustomerVoucherDiscountBrl(sale);
-      sale.total_sold = +sale.total_sold.toFixed(2);
+      sale.discount = +getCustomerVoucherDiscountBrl(sale).toFixed(2);
     }
 
     sale.quantity = sale.items.reduce(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestor-de-vendas",
-  "version": "14.4.9",
+  "version": "14.4.10",
   "author": "Amabest",
   "homepage": "./",
   "description": "Gestor de Vendas",

--- a/src/containers/Actions/index.tsx
+++ b/src/containers/Actions/index.tsx
@@ -156,10 +156,23 @@ const Actions: React.FC<ComponentProps> = ({ history }) => {
               </div>
             </Tooltip>
 
-            <Button onClick={() => discountModalHandler.openDiscoundModal()} disabled={isSavingSale}>
-              <OfferIcon />
-              Desconto [R]
-            </Button>
+            <Tooltip
+              title={
+                sale?.customerVoucher
+                  ? "Remova o cupom antes de aplicar desconto manual."
+                  : ""
+              }
+            >
+              <div>
+                <Button
+                  onClick={() => discountModalHandler.openDiscoundModal()}
+                  disabled={isSavingSale || !!sale?.customerVoucher}
+                >
+                  <OfferIcon />
+                  Desconto [R]
+                </Button>
+              </div>
+            </Tooltip>
 
             <Button onClick={() => setHandlerInState(true)} disabled={isSavingSale}>
               <InputIcon />

--- a/src/containers/CupomModal/index.tsx
+++ b/src/containers/CupomModal/index.tsx
@@ -2,7 +2,60 @@ import React, { useEffect, useState, Dispatch, SetStateAction } from "react";
 
 import { notification } from "antd";
 import { useSale } from "../../hooks/useSale";
+import {
+  computeDiscountByQuantity,
+  DiscountByQuantityResult,
+} from "../../helpers/discountByQuantity";
+import { DiscountByQuantityConfig } from "../../models/dtos/voucher";
 import { Container, Row, Col, InputCode, Button } from "./styles";
+
+type ProductForLabel = {
+  product_id?: number;
+  product?: {
+    id?: number;
+    name?: string;
+    category?: { id?: number; name?: string };
+  };
+};
+
+function buildTriggerLabel(
+  config: DiscountByQuantityConfig,
+  products: ProductForLabel[] | undefined | null,
+  fallbackCupomName: string
+): string {
+  const triggerIds = (config.trigger_ids ?? []).map((v) => Number(v));
+  const list = products ?? [];
+
+  const names: string[] = [];
+  const seen = new Set<string>();
+  const push = (name: string | undefined) => {
+    if (!name) return;
+    const trimmed = name.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    names.push(trimmed);
+  };
+
+  if (config.trigger_mode === "product") {
+    for (const p of list) {
+      const id = p.product?.id ?? p.product_id;
+      if (id !== undefined && triggerIds.includes(Number(id))) {
+        push(p.product?.name);
+      }
+    }
+  } else {
+    for (const p of list) {
+      const catId = p.product?.category?.id;
+      if (catId !== undefined && triggerIds.includes(Number(catId))) {
+        push(p.product?.category?.name);
+      }
+    }
+  }
+
+  if (names.length === 0) return `"${fallbackCupomName}"`;
+  if (names.length <= 2) return names.join(", ");
+  return `${names.slice(0, 2).join(", ")} e outros`;
+}
 
 interface ICupomProps {
   cupomModalState: boolean;
@@ -81,6 +134,13 @@ const CupomModal: React.FC<ICupomProps> = ({
       });
     }
 
+    if (sale.discount > 0 && !sale.customerVoucher) {
+      return notification.warn({
+        message: "Remova o desconto manual antes de aplicar o cupom.",
+        duration: 5,
+      });
+    }
+
     // if (sale.items.length === 0) {
     //   return notification.warn({
     //     message:
@@ -104,6 +164,65 @@ const CupomModal: React.FC<ICupomProps> = ({
       const { response: products } = await window.Main.product.getProducts(
         true
       );
+
+      if (
+        response.voucher.voucher_type === "discount_by_quantity" &&
+        response.voucher.voucher_config
+      ) {
+        const result: DiscountByQuantityResult = computeDiscountByQuantity(
+          response.voucher.voucher_config,
+          sale.items
+        );
+
+        if (result.ok === false) {
+          const nomeCupom = response.voucher.name;
+          const rotuloGatilho = buildTriggerLabel(
+            response.voucher.voucher_config,
+            products,
+            nomeCupom
+          );
+
+          let message: string;
+          if (result.reason === "no_eligible_items") {
+            message = `O cupom "${nomeCupom}" não se aplica aos itens do carrinho. Adicione ${rotuloGatilho} para usá-lo.`;
+          } else if (result.reason === "below_min_quantity") {
+            message = `Faltam ${result.needed} item(ns) para ativar o cupom "${nomeCupom}". Você tem ${result.current} de ${result.required} necessários. Adicione mais ${rotuloGatilho} e tente novamente.`;
+          } else {
+            message = `Para o cupom "${nomeCupom}", cada item que paga precisa ter no mínimo ${result.requiredGrammage}g. Confira a pesagem dos itens antes de aplicar.`;
+          }
+
+          return notification.warn({ message, duration: 8 });
+        }
+
+        const payload = {
+          ...sale,
+          customerVoucher: response,
+          discount: +result.discountBrl.toFixed(2),
+        };
+
+        const {
+          response: updatedSale,
+          has_internal_error: errorOnUpdateSale,
+        } = await window.Main.sale.updateSale(sale.id, payload);
+
+        if (errorOnUpdateSale) {
+          return notification.error({
+            message:
+              errorOnUpdateSale ||
+              "Oops, ocorreu um erro ao atualizar a venda!",
+            duration: 5,
+          });
+        }
+
+        setSale(updatedSale);
+        notification.success({
+          message: "Cupom aplicado com sucesso",
+          duration: 5,
+        });
+        setCupomModalState(false);
+        return;
+      }
+
       delete response.voucher.companies;
 
       response.voucher.products = [...(response.voucher.products || [])];
@@ -139,7 +258,7 @@ const CupomModal: React.FC<ICupomProps> = ({
         const payload = {
           ...sale,
           customerVoucher: response,
-          total_sold: sale.total_sold - discountAmount,
+          discount: +discountAmount.toFixed(2),
         };
 
         const { response: updatedSale, has_internal_error: errorOnUpdateSale } =
@@ -273,7 +392,7 @@ const CupomModal: React.FC<ICupomProps> = ({
       const payload = {
         ...sale,
         customerVoucher: response,
-        total_sold: sale.total_sold - totalDiscount,
+        discount: +totalDiscount.toFixed(2),
       };
 
       const { response: updatedSale, has_internal_error: errorOnUpdateSale } =

--- a/src/containers/Items/index.tsx
+++ b/src/containers/Items/index.tsx
@@ -14,6 +14,11 @@ import {
   ItemContainer,
   ItemContent,
   EmptyContainer,
+  CouponRow,
+  CouponLeft,
+  CouponTag,
+  CouponName,
+  CouponValue,
 } from "./styles";
 
 const Items: React.FC = () => {
@@ -51,30 +56,19 @@ const Items: React.FC = () => {
               {sale?.items?.map((item) => (
                 <Item key={item.id} item={item} />
               ))}
-              {(() => {
-                if (!sale?.customerVoucher) return null;
-                if (sale?.customerVoucher?.voucher?.products?.length) return null;
-                if (!sale?.items?.length) return null;
-                const sumItems = sale.items.reduce(
-                  (total, item) => total + item.total,
-                  0
-                );
-                const discountAmount = sumItems - sale.total_sold;
-                if (discountAmount <= 0) return null;
-                return (
-                  <Item
-                    key="cupom-general-discount"
-                    productVoucher={{
-                      product_name: `Desconto - ${
-                        sale.customerVoucher.voucher?.name || "Cupom"
-                      }`,
-                      price_sell: discountAmount.toFixed(2),
-                      is_registred: true,
-                      in_sale: true,
-                    }}
-                  />
-                );
-              })()}
+              {sale?.customerVoucher && sale?.discount > 0 && (
+                <CouponRow>
+                  <CouponLeft>
+                    <CouponTag>Cupom</CouponTag>
+                    <CouponName>
+                      {sale.customerVoucher.voucher?.name || "Desconto aplicado"}
+                    </CouponName>
+                  </CouponLeft>
+                  <CouponValue>
+                    − R$ {sale.discount.toFixed(2).replace(".", ",")}
+                  </CouponValue>
+                </CouponRow>
+              )}
             </ItemContent>
           </ItemContainer>
         </>

--- a/src/containers/Items/styles.ts
+++ b/src/containers/Items/styles.ts
@@ -63,6 +63,61 @@ export const ItemContent = styled.div`
   margin-top: 8px;
 `;
 
+export const CouponRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  margin-top: 8px;
+  background: var(--soft-orange);
+  border-left: 3px solid var(--color-theme);
+  border-radius: 3px;
+  font-size: 1rem;
+
+  @media (max-width: 1600px) {
+    font-size: 0.9rem;
+  }
+
+  @media (max-width: 1440px) {
+    font-size: 0.85rem;
+  }
+`;
+
+export const CouponLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+`;
+
+export const CouponTag = styled.span`
+  display: inline-flex;
+  align-items: center;
+  background: var(--color-theme);
+  color: var(--white);
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  flex-shrink: 0;
+`;
+
+export const CouponName = styled.span`
+  color: var(--gray-300);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const CouponValue = styled.span`
+  color: var(--color-theme);
+  font-weight: bold;
+  flex-shrink: 0;
+`;
+
 export const EmptyContainer = styled.div`
   display: flex;
   align-items: center;

--- a/src/containers/NfeForm/index.tsx
+++ b/src/containers/NfeForm/index.tsx
@@ -20,6 +20,7 @@ import { PaymentNfe } from "../../models/dtos/paymentNfe";
 import { SaleFromApi } from "../../models/dtos/salesFromApi";
 
 import { useStore } from "../../hooks/useStore";
+import { getVoucherDiscountBrlFromVoucherAndItems } from "../../helpers/voucherDiscountBrl";
 
 type IProps = {
   modalState: boolean;
@@ -63,22 +64,29 @@ const NfeForm: React.FC<IProps> = ({
       setProductsNfe(products);
       setPaymentsNfe(payments);
 
-      const voucherDiscount =
-        JSON.parse(sale.cupom)?.voucher?.products?.reduce(
-          (sum, product) => sum + +product?.price_sell,
-          0
-        ) || 0;
+      // Fallback retroativo: vendas pré-migração têm discount=0 com cupom anexado.
+      // Recomputa via helper canônico (filtra por itens do carrinho — sem o bug do R$120).
+      const persistedDiscount = +sale.discount || 0;
+      const voucherForDiscount = sale.cupom
+        ? JSON.parse(sale.cupom)?.voucher
+        : null;
+      const fallbackDiscount =
+        persistedDiscount === 0 && voucherForDiscount
+          ? getVoucherDiscountBrlFromVoucherAndItems(
+              voucherForDiscount,
+              sale.items
+            )
+          : 0;
+      const effectiveDiscount = persistedDiscount || fallbackDiscount;
 
       form.setFieldsValue({
         total_sold: sale.total_sold.toFixed(2).replace(".", ","),
-        discount: (+sale.discount + voucherDiscount)
-          .toFixed(2)
-          .replace(".", ","),
+        discount: effectiveDiscount.toFixed(2).replace(".", ","),
       });
 
       setNfe((oldValues) => ({
         ...oldValues,
-        discount: +sale.discount + voucherDiscount,
+        discount: effectiveDiscount,
         change_amount: +sale.change_amount,
         total: sale.total_sold,
         store_id: store.company_id,

--- a/src/containers/Payments/index.tsx
+++ b/src/containers/Payments/index.tsx
@@ -261,7 +261,7 @@ const PaymentsContainer: React.FC<IProps> = ({
               {((sale.customer_nps_reward_discount || 0) + sale?.discount)
                 .toFixed(2)
                 .replace(".", ",")}
-              {sale?.discount > 0 && (
+              {sale?.discount > 0 && !sale?.customerVoucher && (
                 <RemoveIcon onClick={() => onRemoveDiscount(sale.id)} />
               )}
             </ValueAmountPositive>

--- a/src/context/globalContext.tsx
+++ b/src/context/globalContext.tsx
@@ -352,7 +352,14 @@ export function GlobalProvider({ children }) {
 
     }
 
-    const voucherDiscount = getCustomerVoucherDiscountBrl(currentSale);
+    // Fallback retroativo: vendas antigas com sale.discount=0 mas cupom anexado
+    // recomputam o desconto via helper. Vendas pós-migração já têm sale.discount populado.
+    const persistedDiscount = +currentSale.discount || 0;
+    const voucherDiscount =
+      persistedDiscount === 0 && currentSale.customerVoucher?.voucher
+        ? getCustomerVoucherDiscountBrl(currentSale)
+        : 0;
+    const effectiveDiscount = persistedDiscount || voucherDiscount;
 
     if (currentSale.customerVoucher?.id) {
       const { has_internal_error: errorOnMarkAsUsedVoucher, error_message } =
@@ -406,9 +413,7 @@ export function GlobalProvider({ children }) {
 
       const nfePayload = {
         cpf: currentSale?.cpf_used_nfce ? currentSale?.client_cpf : null,
-        discount: voucherDiscount
-          ? +currentSale?.discount + +voucherDiscount
-          : currentSale.discount,
+        discount: effectiveDiscount,
         change_amount: +currentSale.change_amount,
         total: total,
         store_id: +store.company_id,
@@ -560,15 +565,10 @@ export function GlobalProvider({ children }) {
     });
 
     if (settings.should_print_sale && settings.should_use_printer) {
-      const discountVouncherCombined = (
-        voucherDiscount
-          ? +currentSale?.discount + +voucherDiscount
-          : currentSale?.discount
-      )?.toString();
       //@ts-expect-error
       window.Main.common.printSale({
         ...currentSale,
-        discount: discountVouncherCombined,
+        discount: effectiveDiscount.toString(),
       });
     }
     const { response: _storeCash } = await window.Main.storeCash.getCurrent();
@@ -604,6 +604,14 @@ export function GlobalProvider({ children }) {
       return notification.warning({
         message: "Não é possível aplicar este desconto",
         description: `Adicione produtos para aplicar desconto`,
+        duration: 5,
+      });
+    }
+
+    if (sale.customerVoucher) {
+      return notification.warning({
+        message: "Não é possível aplicar este desconto",
+        description: `Remova o cupom antes de aplicar desconto manual.`,
         duration: 5,
       });
     }

--- a/src/helpers/discountByQuantity.ts
+++ b/src/helpers/discountByQuantity.ts
@@ -1,0 +1,173 @@
+import { DiscountByQuantityConfig } from "../models/dtos/voucher";
+
+export type CartLineForDiscountByQuantity = {
+  id?: string;
+  total: number;
+  quantity?: number;
+  product: {
+    id: number;
+    category?: { id: number };
+  };
+};
+
+export type DiscountByQuantityResult =
+  | { ok: true; discountBrl: number; awardedItemIds: string[] }
+  | { ok: false; reason: "no_eligible_items" }
+  | {
+      ok: false;
+      reason: "below_min_quantity";
+      needed: number;
+      current: number;
+      required: number;
+    }
+  | {
+      ok: false;
+      reason: "grammage_not_met";
+      requiredGrammage: number;
+    };
+
+type Unit = {
+  itemId: string | undefined;
+  unitPrice: number;
+  isSelfService: boolean;
+  grammage: number | null;
+};
+
+const SELF_SERVICE_PRODUCT_ID = 1;
+
+export function computeDiscountByQuantity(
+  config: DiscountByQuantityConfig,
+  items: CartLineForDiscountByQuantity[],
+): DiscountByQuantityResult {
+  // Passo 0: coerção defensiva. O backend pode serializar numéricos como string.
+  const minCombined = Number(config.min_combined_quantity);
+  const quantityWithDiscount = Number(config.quantity_with_discount);
+  const discountValue = Number(config.discount_value);
+  const minGrammage =
+    config.min_item_grammage === null || config.min_item_grammage === undefined
+      ? null
+      : Number(config.min_item_grammage);
+  const triggerIds = (config.trigger_ids ?? []).map((v) => Number(v));
+
+  if (
+    !Number.isFinite(minCombined) ||
+    !Number.isFinite(quantityWithDiscount) ||
+    !Number.isFinite(discountValue) ||
+    (minGrammage !== null && !Number.isFinite(minGrammage)) ||
+    triggerIds.some((v) => !Number.isFinite(v))
+  ) {
+    return { ok: false, reason: "no_eligible_items" };
+  }
+
+  // 1. Filtrar itens elegíveis pelo trigger_mode.
+  const eligibleItems = items.filter((item) => {
+    if (config.trigger_mode === "product") {
+      return triggerIds.includes(item.product.id);
+    }
+    const categoryId = item.product.category?.id;
+    return categoryId !== undefined && triggerIds.includes(categoryId);
+  });
+
+  if (eligibleItems.length === 0) {
+    return { ok: false, reason: "no_eligible_items" };
+  }
+
+  // 2. Expandir em unidades.
+  //    - Self-service: 1 linha = 1 unidade. unitPrice = item.total (NUNCA dividir por
+  //      quantity, que é peso em KG). grammage = quantity * 1000.
+  //    - Não-self-service: 1 linha gera item.quantity unidades. unitPrice = total / quantity.
+  //      grammage = null (regra ignorada — só faz sentido pra peso variável).
+  const units: Unit[] = [];
+  for (const item of eligibleItems) {
+    const isSelfService = item.product.id === SELF_SERVICE_PRODUCT_ID;
+    if (isSelfService) {
+      const weightKg = item.quantity;
+      units.push({
+        itemId: item.id,
+        unitPrice: item.total,
+        isSelfService: true,
+        grammage: typeof weightKg === "number" ? weightKg * 1000 : null,
+      });
+    } else {
+      const rawQuantity = item.quantity;
+      const unitCount =
+        typeof rawQuantity === "number"
+          ? Math.max(1, Math.round(rawQuantity))
+          : 1;
+      const unitPrice = item.total / unitCount;
+      for (let i = 0; i < unitCount; i++) {
+        units.push({
+          itemId: item.id,
+          unitPrice,
+          isSelfService: false,
+          grammage: null,
+        });
+      }
+    }
+  }
+
+  if (units.length < minCombined) {
+    return {
+      ok: false,
+      reason: "below_min_quantity",
+      required: minCombined,
+      current: units.length,
+      needed: minCombined - units.length,
+    };
+  }
+
+  // 3. Ordenar unidades por unitPrice (asc/desc conforme apply_discount_on).
+  units.sort((a, b) =>
+    config.apply_discount_on === "cheapest"
+      ? a.unitPrice - b.unitPrice
+      : b.unitPrice - a.unitPrice,
+  );
+
+  // 4. Recortar as primeiras minCombined unidades; dentro do recorte,
+  //    as quantityWithDiscount primeiras são premiadas, as demais "pagas contadas".
+  const slice = units.slice(0, minCombined);
+  const awarded = slice.slice(0, quantityWithDiscount);
+  const paidCounted = slice.slice(quantityWithDiscount);
+
+  // 5. Gramatura: aplica APENAS às "pagas contadas" que são self-service.
+  //    Premiadas, unidades fora do recorte e itens unitários ficam de fora —
+  //    a regra só faz sentido pra peso variável, e a especificação fala
+  //    em "itens não premiados que ENTRAM NA CONTAGEM".
+  if (minGrammage !== null) {
+    const failsGrammage = paidCounted.some(
+      (u) =>
+        u.isSelfService && u.grammage !== null && u.grammage < minGrammage,
+    );
+    if (failsGrammage) {
+      return {
+        ok: false,
+        reason: "grammage_not_met",
+        requiredGrammage: minGrammage,
+      };
+    }
+  }
+
+  // 6. Calcular desconto somando por unidade premiada.
+  let discountBrl = 0;
+  for (const u of awarded) {
+    if (config.discount_mode === "percent") {
+      discountBrl += u.unitPrice * (discountValue / 100);
+    } else {
+      discountBrl += Math.min(u.unitPrice, discountValue);
+    }
+  }
+
+  const awardedIdSet = new Set<string>();
+  for (const u of awarded) {
+    if (u.itemId !== undefined) {
+      awardedIdSet.add(u.itemId);
+    }
+  }
+  const awardedItemIds = Array.from(awardedIdSet);
+
+  return {
+    ok: true,
+    discountBrl: +discountBrl.toFixed(2),
+    awardedItemIds,
+  };
+}

--- a/src/helpers/voucherDiscountBrl.ts
+++ b/src/helpers/voucherDiscountBrl.ts
@@ -1,8 +1,12 @@
 import { SaleDto } from "../models/dtos/sale";
+import { CouponConfig } from "../models/dtos/voucher";
+import { computeDiscountByQuantity } from "./discountByQuantity";
 
 export type CartLineForVoucherDiscount = {
-  product: { id: number };
+  id?: string;
+  product: { id: number; category?: { id: number } };
   total: number;
+  quantity?: number;
 };
 
 export type VoucherProductForDiscount = {
@@ -18,6 +22,8 @@ export type VoucherForDiscount = {
   self_service_discount_type: number;
   price_sell: string;
   products?: VoucherProductForDiscount[];
+  voucher_type?: string | null;
+  voucher_config?: CouponConfig | null;
 };
 
 function isSyntheticSelfServiceDiscountLine(
@@ -41,6 +47,14 @@ export function getVoucherDiscountBrlFromVoucherAndItems(
 ): number {
   if (!voucher) {
     return 0;
+  }
+
+  if (
+    voucher.voucher_type === "discount_by_quantity" &&
+    voucher.voucher_config
+  ) {
+    const result = computeDiscountByQuantity(voucher.voucher_config, items);
+    return result.ok ? result.discountBrl : 0;
   }
 
   const products = voucher.products ?? [];

--- a/src/models/dtos/voucher.ts
+++ b/src/models/dtos/voucher.ts
@@ -17,6 +17,21 @@ export type Voucher = {
   points_multiplier: number;
   companies: Company[];
   products: ProductVoucher[];
+  voucher_type?: string | null;
+  voucher_config?: CouponConfig | null;
+};
+
+export type CouponConfig = DiscountByQuantityConfig;
+
+export type DiscountByQuantityConfig = {
+  trigger_mode: "product" | "category";
+  trigger_ids: number[];
+  min_combined_quantity: number;
+  quantity_with_discount: number;
+  apply_discount_on: "cheapest" | "most_expensive";
+  discount_value: number;
+  discount_mode: "percent" | "fixed";
+  min_item_grammage: number | null;
 };
 
 type Company = {

--- a/src/pages/Sale/index.tsx
+++ b/src/pages/Sale/index.tsx
@@ -227,6 +227,21 @@ const Sale: React.FC<IProps> = () => {
       ? getVoucherDiscountBrlFromVoucherAndItems(voucherData.voucher, selectedSale.items)
       : 0;
 
+  // Fallback retroativo: vendas pré-migração têm discount=0 com cupom anexado.
+  // Pós-migração, selectedSale.discount já contém o desconto correto.
+  const persistedDiscount = +(selectedSale?.discount || 0);
+  const effectiveDiscount = persistedDiscount || voucherDiscount;
+
+  // Separação semântica para UI: cupom e desconto manual são mutuamente exclusivos
+  // pós-migração. Se há cupom anexado, persistedDiscount representa o desconto do
+  // cupom (não manual). Pré-migração, persistedDiscount=0 e voucherDiscount cobre via fallback.
+  const hasVoucher = !!voucherData?.voucher;
+  const voucherDiscountAmount = hasVoucher
+    ? persistedDiscount || voucherDiscount
+    : 0;
+  const manualDiscountAmount = hasVoucher ? 0 : persistedDiscount;
+  const totalDiscountAmount = voucherDiscountAmount + manualDiscountAmount;
+
   const handleEmit = async () => {
     if (!selectedSale.items.length) {
       return notification.warning({
@@ -241,7 +256,7 @@ const Sale: React.FC<IProps> = () => {
       email: "",
       store_id: store.company_id,
       total: selectedSale.total_sold,
-      discount: +selectedSale.discount + voucherDiscount,
+      discount: effectiveDiscount,
       change_amount: +selectedSale.change_amount,
       items: selectedSale.items.map((product) => ({
         product_store_id: product.product_store_id,
@@ -660,16 +675,8 @@ const Sale: React.FC<IProps> = () => {
                 </SearchContainer>
                 <ListSaleContainer>
                   <HeaderTable>
-                    <Col
-                      sm={
-                        +selectedSale?.discount > 0 || voucherDiscount > 0
-                          ? 2
-                          : 4
-                      }
-                    >
-                      ID
-                    </Col>
-                    {+selectedSale?.discount > 0 || voucherDiscount > 0 ? (
+                    <Col sm={totalDiscountAmount > 0 ? 2 : 4}>ID</Col>
+                    {totalDiscountAmount > 0 ? (
                       <Col sm={2}>DESCONTO</Col>
                     ) : null}
                     <Col sm={4}>VALOR</Col>
@@ -684,37 +691,20 @@ const Sale: React.FC<IProps> = () => {
                       <Panel
                         header={
                           <>
-                            <Col
-                              sm={
-                                +selectedSale?.discount > 0 ||
-                                voucherDiscount > 0
-                                  ? 2
-                                  : 4
-                              }
-                            >
+                            <Col sm={totalDiscountAmount > 0 ? 2 : 4}>
                               {selectedSale.id}
                             </Col>
-                            {+selectedSale?.discount > 0 ||
-                            voucherDiscount > 0 ? (
+                            {totalDiscountAmount > 0 ? (
                               <Col sm={2}>
                                 <Tooltip
                                   title={
-                                    +selectedSale.discount > 0 &&
-                                    voucherDiscount > 0
-                                      ? `Desconto manual: R$ ${currencyFormater(
-                                          +selectedSale.discount
-                                        )}, Desconto promocional: R$ ${currencyFormater(
-                                          voucherDiscount
-                                        )} - ${voucherName}`
-                                      : +selectedSale.discount > 0
-                                      ? `Desconto manual: R$ ${currencyFormater(
-                                          +selectedSale.discount
-                                        )}`
-                                      : voucherDiscount > 0
+                                    voucherDiscountAmount > 0
                                       ? `Desconto promocional: R$ ${currencyFormater(
-                                          voucherDiscount
+                                          voucherDiscountAmount
                                         )} - ${voucherName}`
-                                      : ""
+                                      : `Desconto manual: R$ ${currencyFormater(
+                                          manualDiscountAmount
+                                        )}`
                                   }
                                 >
                                   <div
@@ -725,20 +715,12 @@ const Sale: React.FC<IProps> = () => {
                                       gap: "2px",
                                     }}
                                   >
-                                    {voucherDiscount ? (
+                                    {voucherDiscountAmount > 0 ? (
                                       <IconOfferDiscount></IconOfferDiscount>
                                     ) : (
                                       <></>
                                     )}
-                                    R${" "}
-                                    {voucherDiscount
-                                      ? currencyFormater(
-                                          +selectedSale.discount +
-                                            +voucherDiscount
-                                        )
-                                      : currencyFormater(
-                                          +selectedSale.discount
-                                        )}
+                                    R$ {currencyFormater(totalDiscountAmount)}
                                   </div>
                                 </Tooltip>
                               </Col>

--- a/src/pages/Totem/components/Cupom/index.tsx
+++ b/src/pages/Totem/components/Cupom/index.tsx
@@ -50,6 +50,15 @@ const Cupom: React.FC<IProps> = ({ setStep }) => {
         setVisibleInvalidCupom(true);
         return;
       }
+
+      if (response.voucher?.voucher_type === "discount_by_quantity") {
+        setErrorMesssage(
+          "Este cupom não está disponível no totem. Utilize o caixa."
+        );
+        setVisibleInvalidCupom(true);
+        return;
+      }
+
       setCustomerVoucher(response);
 
       const { response: products } =


### PR DESCRIPTION
## Resumo

Migra o desconto do cupom (todos os tipos: legacy A, legacy B e novo `discount_by_quantity`) para popular o campo `sale.discount` em vez de subtrair de `sale.total_sold`. Bloqueia desconto manual e cupom como mutuamente exclusivos, corrige um bug crítico na reemissão de NFCe e adiciona uma linha visual estilizada para o cupom no carrinho.

## Por quê

- `sale.discount` ficava `0` no banco — quem precisava do desconto (NFCe, NfeForm modal, reissue via tela Sales) reconstruía o valor e bugava.
- **Bug crítico corrigido em `NfeForm`**: somava `price_sell` de TODOS os produtos do voucher sem filtrar pelo carrinho (voucher com 4 produtos × R$30 → discount sugerido R$120 em vez de R$30).
- Precisão flutuante em `total_sold` causava erro "Pagamento inválido" mesmo com input igual ao total exibido.

## O que mudou

- **Modelo de dados**: `total_sold = sum(items)` raw; `sale.discount` carrega o desconto do voucher OU do manual (mutex).
- **CupomModal** (3 branches): passa a gravar `discount` em vez de mexer em `total_sold`. Recusa cupom se já há desconto manual aplicado.
- **addItem/decressItem** (electron): recomputam `sale.discount` via `getCustomerVoucherDiscountBrl` em vez de subtrair de `total_sold`.
- **NFCe e print** (`onRegisterSale`): usam `sale.discount` direto com fallback retroativo via helper para vendas pré-migração.
- **NfeForm**: bug do R$120 corrigido — usa o helper canônico (filtra por items do carrinho) com fallback.
- **Sale page**: payload da reemissão usa `selectedSale.discount` direto + fallback retroativo. Tooltip e coluna DESCONTO separam corretamente "promocional" vs "manual" (não dobra mais).
- **Actions**: botão "Desconto [R]" desabilitado quando há cupom, com tooltip.
- **Payments widget**: `RemoveIcon` no R$ Desconto só aparece se for manual (não cupom).
- **Items container**: linha visual estilizada do cupom (badge "CUPOM" + nome + valor) na paleta do projeto.
- **Totem**: bloqueia `voucher_type === "discount_by_quantity"` com mensagem clara. Legacy do totem fica intocado por enquanto.

## Compatibilidade retroativa

Vendas finalizadas ANTES desta migração (`discount: "0.00"` com cupom anexado) continuam funcionando via fallback: se `discount === 0` e há `customerVoucher`, recomputa via helper. Pós-migração, nunca cai no fallback.